### PR TITLE
configure esbuild for Node.js environment with dual module support

### DIFF
--- a/.changeset/puny-icons-play.md
+++ b/.changeset/puny-icons-play.md
@@ -1,0 +1,6 @@
+---
+'@brionmario-experimental/mcp-express': patch
+'@brionmario-experimental/mcp-node': patch
+---
+
+configure esbuild for Node.js environment with dual module support

--- a/packages/mcp-express/build.js
+++ b/packages/mcp-express/build.js
@@ -10,8 +10,7 @@ const commonOptions = {
   entryPoints: ['src/index.ts'],
   bundle: true,
   platform: 'node',
-  // External dependencies that shouldn't be bundled
-  external: ['express', 'cors', '@brionmario-experimental/mcp-node'],
+  external: ['jose', 'node-fetch'], // External dependencies that shouldn't be bundled
   sourcemap: true,
   minify: true,
   target: 'node18', // Target Node.js version
@@ -44,7 +43,8 @@ async function buildCJS() {
 // Generate TypeScript declaration files
 async function generateTypes() {
   try {
-    await execAsync('tsc --emitDeclarationOnly --declaration --outDir dist');
+    // Using the lib config to generate declarations
+    await execAsync('tsc -p tsconfig.lib.json --emitDeclarationOnly');
     console.log('✅ TypeScript declarations generated');
   } catch (error) {
     console.error('❌ Error generating TypeScript declarations:', error);

--- a/packages/mcp-express/build.js
+++ b/packages/mcp-express/build.js
@@ -1,0 +1,81 @@
+import {build} from 'esbuild';
+import {exec} from 'child_process';
+import {promisify} from 'util';
+import fs from 'fs';
+
+const execAsync = promisify(exec);
+
+// Common build options
+const commonOptions = {
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  platform: 'node',
+  // External dependencies that shouldn't be bundled
+  external: ['express', 'cors', '@brionmario-experimental/mcp-node'],
+  sourcemap: true,
+  minify: true,
+  target: 'node18', // Target Node.js version
+};
+
+// Build ESM version
+async function buildESM() {
+  await build({
+    ...commonOptions,
+    outfile: 'dist/index.js',
+    format: 'esm',
+  });
+  console.log('✅ ESM build complete');
+}
+
+// Build CommonJS version
+async function buildCJS() {
+  await build({
+    ...commonOptions,
+    outfile: 'dist/cjs/index.js',
+    format: 'cjs',
+  });
+
+  // Create a package.json for the CJS directory to specify type
+  fs.mkdirSync('dist/cjs', {recursive: true});
+  fs.writeFileSync('dist/cjs/package.json', JSON.stringify({type: 'commonjs'}, null, 2));
+  console.log('✅ CJS build complete');
+}
+
+// Generate TypeScript declaration files
+async function generateTypes() {
+  try {
+    await execAsync('tsc --emitDeclarationOnly --declaration --outDir dist');
+    console.log('✅ TypeScript declarations generated');
+  } catch (error) {
+    console.error('❌ Error generating TypeScript declarations:', error);
+    process.exit(1);
+  }
+}
+
+// Clean previous build
+async function clean() {
+  try {
+    await execAsync('rm -rf dist');
+    console.log('✅ Previous build cleaned');
+  } catch (error) {
+    console.error('❌ Error cleaning previous build:', error);
+  }
+}
+
+// Main build function
+async function runBuild() {
+  try {
+    console.log('🚀 Starting build process...');
+
+    await clean();
+    await Promise.all([buildESM(), buildCJS()]);
+    await generateTypes();
+
+    console.log('✅ Build completed successfully!');
+  } catch (error) {
+    console.error('❌ Build failed:', error);
+    process.exit(1);
+  }
+}
+
+runBuild();

--- a/packages/mcp-express/build.js
+++ b/packages/mcp-express/build.js
@@ -1,3 +1,4 @@
+// build.js
 import {build} from 'esbuild';
 import {exec} from 'child_process';
 import {promisify} from 'util';
@@ -10,7 +11,8 @@ const commonOptions = {
   entryPoints: ['src/index.ts'],
   bundle: true,
   platform: 'node',
-  external: ['jose', 'node-fetch'], // External dependencies that shouldn't be bundled
+  // External dependencies that shouldn't be bundled
+  external: ['express', 'cors', '@brionmario-experimental/mcp-node'],
   sourcemap: true,
   minify: true,
   target: 'node18', // Target Node.js version

--- a/packages/mcp-express/package.json
+++ b/packages/mcp-express/package.json
@@ -21,8 +21,7 @@
   "module": "dist/index.js",
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/cjs/index.js",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/cjs/index.js"
   },
   "files": [
     "dist",
@@ -38,7 +37,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "node build.js",
-    "build:types": "tsc -p tsconfig.lib.json --emitDeclarationOnly",
+    "build:types": "tsc --emitDeclarationOnly --declaration",
     "build:esm": "esbuild src/index.ts --bundle --platform=node --outfile=dist/index.js --format=esm --sourcemap --minify --external:express --external:cors --external:@brionmario-experimental/mcp-node",
     "build:cjs": "esbuild src/index.ts --bundle --platform=node --outfile=dist/cjs/index.js --format=cjs --sourcemap --minify --external:express --external:cors --external:@brionmario-experimental/mcp-node",
     "fix:lint": "eslint --fix --ext .ts,.js src",

--- a/packages/mcp-express/package.json
+++ b/packages/mcp-express/package.json
@@ -21,7 +21,8 @@
   "module": "dist/index.js",
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist",
@@ -35,7 +36,11 @@
     "directory": "packages/mcp-express"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.lib.json",
+    "clean": "rm -rf dist",
+    "build": "node build.js",
+    "build:types": "tsc -p tsconfig.lib.json --emitDeclarationOnly",
+    "build:esm": "esbuild src/index.ts --bundle --platform=node --outfile=dist/index.js --format=esm --sourcemap --minify --external:express --external:cors --external:@brionmario-experimental/mcp-node",
+    "build:cjs": "esbuild src/index.ts --bundle --platform=node --outfile=dist/cjs/index.js --format=cjs --sourcemap --minify --external:express --external:cors --external:@brionmario-experimental/mcp-node",
     "fix:lint": "eslint --fix --ext .ts,.js src",
     "lint": "eslint --ext .ts,.js src"
   },
@@ -45,6 +50,7 @@
     "@types/node": "^22.15.3",
     "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?4ee6f6be232d7631999d709a86b91612f1d34ce7",
     "@wso2/prettier-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?4ee6f6be232d7631999d709a86b91612f1d34ce7",
+    "esbuild": "^0.25.4",
     "eslint": "8.57.0",
     "prettier": "^2.6.2",
     "typescript": "~5.7.2"
@@ -60,5 +66,8 @@
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "tslib": "^2.8.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/mcp-express/tsconfig.lib.json
+++ b/packages/mcp-express/tsconfig.lib.json
@@ -1,20 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "declaration": true,
-    "outDir": "dist",
-    "declarationDir": "dist",
+    "declarationMap": true,
+    "inlineSources": true,
     "types": ["node"]
   },
-  "exclude": [
-    "**/*.spec.ts",
-    "**/*.test.ts",
-    "**/*.spec.tsx",
-    "**/*.test.tsx",
-    "**/*.spec.js",
-    "**/*.test.js",
-    "**/*.spec.jsx",
-    "**/*.test.jsx"
-  ],
-  "include": ["src/**/*.js", "src/**/*.ts", "types/**/*.d.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"]
 }

--- a/packages/mcp-express/tsconfig.spec.json
+++ b/packages/mcp-express/tsconfig.spec.json
@@ -1,17 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "./dist/spec",
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "include": [
-    "test-configs",
-    "jest.config.js",
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "**/*.test.js",
-    "**/*.spec.js",
-    "**/*.d.ts"
-  ]
+  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]
 }

--- a/packages/mcp-node/build.js
+++ b/packages/mcp-node/build.js
@@ -1,0 +1,81 @@
+import {build} from 'esbuild';
+import {exec} from 'child_process';
+import {promisify} from 'util';
+import fs from 'fs';
+
+const execAsync = promisify(exec);
+
+// Common build options
+const commonOptions = {
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  platform: 'node',
+  external: ['jose', 'node-fetch'], // External dependencies that shouldn't be bundled
+  sourcemap: true,
+  minify: true,
+  target: 'node18', // Target Node.js version
+};
+
+// Build ESM version
+async function buildESM() {
+  await build({
+    ...commonOptions,
+    outfile: 'dist/index.js',
+    format: 'esm',
+  });
+  console.log('✅ ESM build complete');
+}
+
+// Build CommonJS version
+async function buildCJS() {
+  await build({
+    ...commonOptions,
+    outfile: 'dist/cjs/index.js',
+    format: 'cjs',
+  });
+
+  // Create a package.json for the CJS directory to specify type
+  fs.mkdirSync('dist/cjs', {recursive: true});
+  fs.writeFileSync('dist/cjs/package.json', JSON.stringify({type: 'commonjs'}, null, 2));
+  console.log('✅ CJS build complete');
+}
+
+// Generate TypeScript declaration files
+async function generateTypes() {
+  try {
+    // Using the lib config to generate declarations
+    await execAsync('tsc -p tsconfig.lib.json --emitDeclarationOnly');
+    console.log('✅ TypeScript declarations generated');
+  } catch (error) {
+    console.error('❌ Error generating TypeScript declarations:', error);
+    process.exit(1);
+  }
+}
+
+// Clean previous build
+async function clean() {
+  try {
+    await execAsync('rm -rf dist');
+    console.log('✅ Previous build cleaned');
+  } catch (error) {
+    console.error('❌ Error cleaning previous build:', error);
+  }
+}
+
+// Main build function
+async function runBuild() {
+  try {
+    console.log('🚀 Starting build process...');
+
+    await clean();
+    await Promise.all([buildESM(), buildCJS()]);
+    await generateTypes();
+
+    console.log('✅ Build completed successfully!');
+  } catch (error) {
+    console.error('❌ Build failed:', error);
+    process.exit(1);
+  }
+}
+
+runBuild();

--- a/packages/mcp-node/package.json
+++ b/packages/mcp-node/package.json
@@ -22,8 +22,7 @@
   "module": "dist/index.js",
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/cjs/index.js",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/cjs/index.js"
   },
   "files": [
     "dist",

--- a/packages/mcp-node/package.json
+++ b/packages/mcp-node/package.json
@@ -22,7 +22,8 @@
   "module": "dist/index.js",
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist",
@@ -36,7 +37,11 @@
     "directory": "packages/mcp-node"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.lib.json",
+    "clean": "rm -rf dist",
+    "build": "node build.js",
+    "build:types": "tsc --emitDeclarationOnly --declaration",
+    "build:esm": "esbuild src/index.ts --bundle --platform=node --outfile=dist/index.js --format=esm --sourcemap --minify --external:jose --external:node-fetch",
+    "build:cjs": "esbuild src/index.ts --bundle --platform=node --outfile=dist/cjs/index.js --format=cjs --sourcemap --minify --external:jose --external:node-fetch",
     "fix:lint": "eslint --fix --ext .ts,.js src",
     "lint": "eslint --ext .ts,.js src"
   },
@@ -44,6 +49,7 @@
     "@types/node": "^22.15.3",
     "@wso2/eslint-plugin": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/eslint-plugin?4ee6f6be232d7631999d709a86b91612f1d34ce7",
     "@wso2/prettier-config": "https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?4ee6f6be232d7631999d709a86b91612f1d34ce7",
+    "esbuild": "^0.25.4",
     "eslint": "8.57.0",
     "prettier": "^2.6.2",
     "typescript": "~5.7.2"
@@ -55,5 +61,8 @@
     "jose": "^6.0.10",
     "node-fetch": "^3.3.2",
     "tslib": "^2.8.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/mcp-node/tsconfig.json
+++ b/packages/mcp-node/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM", "WebWorker"],
     "module": "ESNext",
     "moduleResolution": "node",
     "skipLibCheck": true,

--- a/packages/mcp-node/tsconfig.lib.json
+++ b/packages/mcp-node/tsconfig.lib.json
@@ -1,20 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "declaration": true,
-    "outDir": "dist",
-    "declarationDir": "dist",
+    "declarationMap": true,
+    "inlineSources": true,
     "types": ["node"]
   },
-  "exclude": [
-    "**/*.spec.ts",
-    "**/*.test.ts",
-    "**/*.spec.tsx",
-    "**/*.test.tsx",
-    "**/*.spec.js",
-    "**/*.test.js",
-    "**/*.spec.jsx",
-    "**/*.test.jsx"
-  ],
-  "include": ["src/**/*.js", "src/**/*.ts", "types/**/*.d.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"]
 }

--- a/packages/mcp-node/tsconfig.spec.json
+++ b/packages/mcp-node/tsconfig.spec.json
@@ -1,17 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "./dist/spec",
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "include": [
-    "test-configs",
-    "jest.config.js",
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "**/*.test.js",
-    "**/*.spec.js",
-    "**/*.d.ts"
-  ]
+  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@wso2/prettier-config':
         specifier: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?4ee6f6be232d7631999d709a86b91612f1d34ce7
         version: https://gitpkg.vercel.app/brionmario/wso2-ui-configs/packages/prettier-config?4ee6f6be232d7631999d709a86b91612f1d34ce7(prettier@2.8.8)(typescript@5.7.3)
+      esbuild:
+        specifier: ^0.25.4
+        version: 0.25.4
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -122,6 +125,9 @@ importers:
       '@wso2/prettier-config':
         specifier: https://gitpkg.now.sh/brionmario/wso2-ui-configs/packages/prettier-config?4ee6f6be232d7631999d709a86b91612f1d34ce7
         version: https://gitpkg.vercel.app/brionmario/wso2-ui-configs/packages/prettier-config?4ee6f6be232d7631999d709a86b91612f1d34ce7(prettier@2.8.8)(typescript@5.7.3)
+      esbuild:
+        specifier: ^0.25.4
+        version: 0.25.4
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -285,6 +291,156 @@ packages:
 
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+
+  '@esbuild/aix-ppc64@0.25.4':
+    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.4':
+    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.4':
+    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.4':
+    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.4':
+    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.4':
+    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.4':
+    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.4':
+    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.4':
+    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.4':
+    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.4':
+    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.4':
+    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.4':
+    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.4':
+    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.4':
+    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.4':
+    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.4':
+    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.4':
+    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.4':
+    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.25.4':
+    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.4':
+    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.4':
+    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.4':
+    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -1047,6 +1203,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2847,6 +3008,81 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@esbuild/aix-ppc64@0.25.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/android-arm@0.25.4':
+    optional: true
+
+  '@esbuild/android-x64@0.25.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.4':
+    optional: true
+
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.0)':
     dependencies:
       eslint: 8.57.0
@@ -3725,6 +3961,34 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.25.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.4
+      '@esbuild/android-arm': 0.25.4
+      '@esbuild/android-arm64': 0.25.4
+      '@esbuild/android-x64': 0.25.4
+      '@esbuild/darwin-arm64': 0.25.4
+      '@esbuild/darwin-x64': 0.25.4
+      '@esbuild/freebsd-arm64': 0.25.4
+      '@esbuild/freebsd-x64': 0.25.4
+      '@esbuild/linux-arm': 0.25.4
+      '@esbuild/linux-arm64': 0.25.4
+      '@esbuild/linux-ia32': 0.25.4
+      '@esbuild/linux-loong64': 0.25.4
+      '@esbuild/linux-mips64el': 0.25.4
+      '@esbuild/linux-ppc64': 0.25.4
+      '@esbuild/linux-riscv64': 0.25.4
+      '@esbuild/linux-s390x': 0.25.4
+      '@esbuild/linux-x64': 0.25.4
+      '@esbuild/netbsd-arm64': 0.25.4
+      '@esbuild/netbsd-x64': 0.25.4
+      '@esbuild/openbsd-arm64': 0.25.4
+      '@esbuild/openbsd-x64': 0.25.4
+      '@esbuild/sunos-x64': 0.25.4
+      '@esbuild/win32-arm64': 0.25.4
+      '@esbuild/win32-ia32': 0.25.4
+      '@esbuild/win32-x64': 0.25.4
 
   escalade@3.2.0: {}
 


### PR DESCRIPTION
### Purpose
Configure esbuild for Node.js environment with dual module support (ESM/CommonJS). This update implements a comprehensive build system that generates both module formats while ensuring proper TypeScript declaration generation and maintaining external dependencies.

Key improvements:
- Added build.js script for automated esbuild process
- Added support for both ESM and CommonJS module formats
- Configured TypeScript declaration generation using existing tsconfig structure

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Manual test round performed and verified.
- [x] Documentation provided.
- [ ] Unit tests provided.

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran ESLint and Prettier fixed any issues.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets